### PR TITLE
Setup options for hotkey options

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "command": "docs.write",
         "key": "ctrl+.",
         "win": "ctrl+.",
-        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == 'Ctrl + .'"
+        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.windows == 'Ctrl + .'"
       },
       {
         "command": "docs.write",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "command": "docs.write",
         "key": "alt+.",
         "win": "alt+.",
-        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.windows == '⎇ + .'"
+        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.windows == 'Alt + .'"
       }
     ],
     "menus": {
@@ -139,8 +139,8 @@
       },
       {
         "view": "docs",
-        "contents": "[✍️ Generate docs (⎇+.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
-        "when": "isWindows && config.docwriter.hotkey.windows == '⎇ + .'"
+        "contents": "[✍️ Generate docs (Alt+.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
+        "when": "isWindows && config.docwriter.hotkey.windows == 'Alt + .'"
       }
     ],
     "views": {
@@ -201,7 +201,7 @@
           "default": "Ctrl + .",
           "enum": [
             "Ctrl + .",
-            "⎇ + ."
+            "Alt + ."
           ],
           "enumDescriptions": [
             "Control + .",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "AI Doc Writer for Python, JavaScript, TypeScript, PHP, and Java",
   "description": "The AI powered documentation writer",
   "icon": "assets/icon.png",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "publisher": "mintlify",
   "keywords": [
     "documentation",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,37 @@
         "command": "docs.write",
         "key": "cmd+.",
         "mac": "cmd+.",
+        "when": "isMac && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == '⌘ + .'"
+      },
+      {
+        "command": "docs.write",
+        "key": "alt+.",
+        "mac": "alt+.",
+        "when": "isMac && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == '⌥ + .'"
+      },
+      {
+        "command": "docs.write",
+        "key": "cmd+.",
+        "mac": "cmd+.",
+        "when": "isLinux && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == '⌘ + .'"
+      },
+      {
+        "command": "docs.write",
+        "key": "alt+.",
+        "mac": "alt+.",
+        "when": "isLinux && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == '⌥ + .'"
+      },
+      {
+        "command": "docs.write",
+        "key": "ctrl+.",
         "win": "ctrl+.",
-        "when": "editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/"
+        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.mac == 'Ctrl + .'"
+      },
+      {
+        "command": "docs.write",
+        "key": "alt+.",
+        "win": "alt+.",
+        "when": "isWindows && editorTextFocus && editorLangId =~ /typescript|javascript|python|php|java/ && config.docwriter.hotkey.windows == '⎇ + .'"
       }
     ],
     "menus": {
@@ -77,15 +106,8 @@
       "activitybar": [
         {
           "id": "mintdocs",
-          "title": "AI Doc Writer (⌘.)",
-          "icon": "assets/outline.png",
-          "when": "isMac || isLinux"
-        },
-        {
-          "id": "mintdocs",
-          "title": "AI Doc Writer (Ctrl+.)",
-          "icon": "assets/outline.png",
-          "when": "isWindows"
+          "title": "AI Doc Writer",
+          "icon": "assets/outline.png"
         }
       ]
     },
@@ -93,12 +115,32 @@
       {
         "view": "docs",
         "contents": "[✍️ Generate docs (⌘.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
-        "when": "isMac || isLinux"
+        "when": "isMac && config.docwriter.hotkey.mac == '⌘ + .'"
+      },
+      {
+        "view": "docs",
+        "contents": "[✍️ Generate docs (⌥.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
+        "when": "isMac && config.docwriter.hotkey.mac == '⌥ + .'"
+      },
+      {
+        "view": "docs",
+        "contents": "[✍️ Generate docs (⌘.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
+        "when": "isLinux && config.docwriter.hotkey.mac == '⌘ + .'"
+      },
+      {
+        "view": "docs",
+        "contents": "[✍️ Generate docs (⌥.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
+        "when": "isLinux && config.docwriter.hotkey.mac == '⌥ + .'"
       },
       {
         "view": "docs",
         "contents": "[✍️ Generate docs (Ctrl+.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
-        "when": "isWindows"
+        "when": "isWindows && config.docwriter.hotkey.windows == 'Ctrl + .'"
+      },
+      {
+        "view": "docs",
+        "contents": "[✍️ Generate docs (⎇+.)](command:docs.write)\nHave questions? Join our [community](https://discord.gg/6W7GuYuxra)",
+        "when": "isWindows && config.docwriter.hotkey.windows == '⎇ + .'"
       }
     ],
     "views": {
@@ -108,8 +150,12 @@
           "name": "AI Generate Docs"
         },
         {
-          "id": "docsOptions",
+          "id": "formatOptions",
           "name": "Docstring Format"
+        },
+        {
+          "id": "hotkeyOptions",
+          "name": "Hotkey Binding"
         }
       ]
     },
@@ -124,18 +170,44 @@
             "JSDoc",
             "reST",
             "DocBlock",
-            "Google",
-            "Javadoc"
+            "Javadoc",
+            "Google"
           ],
           "enumDescriptions": [
             "Automatically configured based on the language",
             "The conventional document format for JavaScript",
             "A documentation format for Python",
             "A documentation format for PHP",
-            "Format from the Google Python Style Guide",
-            "The conventional documentation format for Java"
+            "The conventional documentation format for Java",
+            "Format from the Google Python Style Guide"
           ],
           "description": "The format style of documents generated"
+        },
+        "docwriter.hotkey.mac": {
+          "type": "string",
+          "default": "⌘ + .",
+          "enum": [
+            "⌘ + .",
+            "⌥ + ."
+          ],
+          "enumDescriptions": [
+            "Command + .",
+            "Option + ."
+          ],
+          "description": "The hotkey used for generating documentation (only for Macs)"
+        },
+        "docwriter.hotkey.windows": {
+          "type": "string",
+          "default": "Ctrl + .",
+          "enum": [
+            "Ctrl + .",
+            "⎇ + ."
+          ],
+          "enumDescriptions": [
+            "Control + .",
+            "Alt + ."
+          ],
+          "description": "The hotkey used for generating documentation (only for Windows)"
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,24 @@
-import { env } from 'vscode';
+import { env, workspace } from 'vscode';
 
-const isWindows = () => Boolean(env.appRoot && env.appRoot[0] !== "/");
-
-export const KEYBINDING_DISPLAY = isWindows() ? 'Ctrl+.' : '⌘.';
+export const isWindows = () => Boolean(env.appRoot && env.appRoot[0] !== "/");
+export const hotkeyConfigProperty = () => {
+  if (isWindows()) {
+    return 'hotkey.windows';
+  }
+  return 'hotkey.mac';
+};
+export const KEYBINDING_DISPLAY = (): string => {
+  const hotkeyConfig = workspace.getConfiguration('docwriter').get(hotkeyConfigProperty());
+  switch (hotkeyConfig) {
+    case '⌘ + .':
+      return '⌘ + .';
+    case '⌥ + .':
+      return '⌥.';
+    case 'Ctrl + .':
+      return 'Ctrl+.';
+    case '⎇ + .':
+      return '⎇+.';
+    default:
+      return '⌘ + .';
+  }
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,8 +16,8 @@ export const KEYBINDING_DISPLAY = (): string => {
       return '⌥.';
     case 'Ctrl + .':
       return 'Ctrl+.';
-    case '⎇ + .':
-      return '⎇+.';
+    case 'Alt + .':
+      return 'Alt+.';
     default:
       return '⌘ + .';
   }

--- a/src/hover/provider.ts
+++ b/src/hover/provider.ts
@@ -12,7 +12,7 @@ export default class LanguagesHoverProvider implements HoverProvider {
       if (!highlighted) {return resolve(null);}
 
       const writeCommandUri = Uri.parse('command:docs.write');
-      const showcaseDocstring = new MarkdownString(`[✍️ Generate docs (${KEYBINDING_DISPLAY})](${writeCommandUri})`, true);
+      const showcaseDocstring = new MarkdownString(`[✍️ Generate docs (${KEYBINDING_DISPLAY()})](${writeCommandUri})`, true);
       showcaseDocstring.supportHtml = true;
       showcaseDocstring.isTrusted = true;
       return resolve(new Hover([showcaseDocstring]));

--- a/src/options/format.ts
+++ b/src/options/format.ts
@@ -11,7 +11,7 @@ const FORMAT_OPTIONS = [
   'Google'
 ];
 
-export class OptionsProvider implements vscode.TreeDataProvider<FormatOption> {
+export class FormatOptionsProvider implements vscode.TreeDataProvider<FormatOption> {
   constructor() {}
 
   getTreeItem(element: FormatOption): vscode.TreeItem {
@@ -43,6 +43,7 @@ class FormatOption extends vscode.TreeItem {
     if (this.isDefault) {
       this.description = 'Default';
     }
+
     if (this.selected) {
       this.iconPath = {
         light: path.join(__filename, '..', '..', 'assets', 'light', 'check.svg'),

--- a/src/options/hotkey.ts
+++ b/src/options/hotkey.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { hotkeyConfigProperty, isWindows } from '../constants';
+
+// Options must also match contributes.properties in package.json
+const HOTKEY_OPTIONS_MAC = [
+  '⌘ + .',
+  '⌥ + .',
+];
+const HOTKEY_OPTIONS_WINDOWS = [
+  'Ctrl + .',
+  '⎇ + .',
+];
+
+export class HotkeyOptionsProvider implements vscode.TreeDataProvider<FormatOption> {
+  constructor() {}
+
+  getTreeItem(element: FormatOption): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): FormatOption[] {
+    const docWriterConfig = vscode.workspace.getConfiguration('docwriter');
+    const hotkeyConfig = hotkeyConfigProperty();
+    const defaultValue = docWriterConfig.inspect(hotkeyConfig)?.defaultValue;
+    const currentValue = docWriterConfig.get(hotkeyConfig);
+    const HOTKEY_OPTIONS = isWindows() ? HOTKEY_OPTIONS_WINDOWS : HOTKEY_OPTIONS_MAC;
+    
+    const options = HOTKEY_OPTIONS.map((option) => {
+      const isDefault = option === defaultValue;
+      const selected = option === currentValue;
+      return new FormatOption(option, vscode.TreeItemCollapsibleState.None, isDefault, selected);
+    });
+    return options;
+  }
+}
+
+class FormatOption extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly isDefault: boolean = false,
+    public readonly selected: boolean = false
+  ) {
+    super(label, collapsibleState);
+    this.tooltip = this.label;
+    if (this.isDefault) {
+      this.description = 'Default';
+    }
+
+    if (this.selected) {
+      this.iconPath = {
+        light: path.join(__filename, '..', '..', 'assets', 'light', 'check.svg'),
+        dark: path.join(__filename, '..', '..', 'assets', 'dark', 'check.svg')
+      };
+    }
+    const onClickCommand: vscode.Command = {
+      title: 'Hotkey Config',
+      command: 'docs.hotkeyConfig',
+      arguments: [this.label]
+    };
+
+    this.command = onClickCommand;
+  }
+}

--- a/src/options/hotkey.ts
+++ b/src/options/hotkey.ts
@@ -9,7 +9,7 @@ const HOTKEY_OPTIONS_MAC = [
 ];
 const HOTKEY_OPTIONS_WINDOWS = [
   'Ctrl + .',
-  '⎇ + .',
+  'Alt + .',
 ];
 
 export class HotkeyOptionsProvider implements vscode.TreeDataProvider<FormatOption> {


### PR DESCRIPTION
### Testing instructions:
There are two platforms to test on
1. Macs
2. Windows

And two options for each platform
1. `⌘ + .` . and `⌥ + .` (Macs)
2. `Ctrl + .` and `Alt + .` (Windows)

For three locations to check that's placed correctly
1. The command actually works
2. The label on the button
<img width="228" alt="Screen Shot 2022-02-10 at 1 22 39 AM" src="https://user-images.githubusercontent.com/44352119/153376808-744e0402-d744-44f9-9a35-9baecdf841b0.png">
 3. The hover preview
<img width="327" alt="Screen Shot 2022-02-10 at 1 23 10 AM" src="https://user-images.githubusercontent.com/44352119/153376873-b9cebb51-ae09-4611-9440-d7c46add5248.png">

I only really tested the case for Macs. Please find a Windows to make sure that it also works 